### PR TITLE
runtime: Do not set defaultShim

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -52,6 +52,7 @@ _commonConfig: &commonConfig
 # Shared shim configuration (x86_64)
 # This anchor is reused by both CoCo runtime and CI variant
 _shimsConfig: &x86_64_shims
+  defaultShim: ""
   shims: "qemu-coco-dev qemu-snp qemu-tdx qemu-nvidia-gpu-snp qemu-nvidia-gpu-tdx"
   snapshotterHandlerMapping: "qemu-coco-dev:nydus,qemu-snp:nydus,qemu-tdx:nydus,qemu-nvidia-gpu-snp:nydus,qemu-nvidia-gpu-tdx:nydus"
   pullTypeMapping: "qemu-coco-dev:guest-pull,qemu-snp:guest-pull,qemu-tdx:guest-pull,qemu-nvidia-gpu-snp:guest-pull,qemu-nvidia-gpu-tdx:guest-pull"

--- a/values/kata-s390x.yaml
+++ b/values/kata-s390x.yaml
@@ -12,6 +12,7 @@ _commonConfig: &commonConfig
   k8sDistribution: k8s
 
 _shimsConfig: &s390x_shims
+  defaultShim: ""
   shims: "qemu-coco-dev qemu-se"
   snapshotterHandlerMapping: "qemu-coco-dev:nydus,qemu-se:nydus"
   pullTypeMapping: "qemu-coco-dev:guest-pull,qemu-se:guest-pull"


### PR DESCRIPTION
Kata Containers sets defaultShim to QEMU, which we're not deploying here by default. The best approach we can take is to NOT set it to anything and let it for the users to do whatever they want.