### PR TITLE
tests: e2e: Always run a normal pod after uninstall

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -709,7 +709,7 @@ jobs:
           fi
 
       - name: Test normal pod after cleanup
-        if: always() && matrix.test-containerd-upgrade == 'true'
+        if: always() && steps.should-run.outputs.should-run == 'true'
         run: |
           echo "🧪 Testing normal pod creation after cleanup..."
           echo "This ensures containerd still works for regular (non-Kata) workloads"


### PR DESCRIPTION
So we are sure that whatever we do, we do *NOT* break the cluster.