### PR TITLE
charts: Use `coco-system` as the default namespace

### DIFF
--- a/.github/actions/verify-deployment/action.yaml
+++ b/.github/actions/verify-deployment/action.yaml
@@ -5,7 +5,7 @@ inputs:
   namespace:
     description: 'Kubernetes namespace where chart is installed'
     required: false
-    default: 'kube-system'
+    default: 'coco-system'
   expected-runtime-classes:
     description: 'Space-separated list of expected RuntimeClass names'
     required: false

--- a/.github/scripts/helm-operations.sh
+++ b/.github/scripts/helm-operations.sh
@@ -15,7 +15,7 @@
 #   install RELEASE_NAME [OPTIONS]
 #       Install Helm chart
 #       Options:
-#         --namespace NAME       Kubernetes namespace (default: kube-system)
+#         --namespace NAME       Kubernetes namespace (default: coco-system)
 #         --values-file PATH     Path to values file (optional)
 #         --extra-args ARGS      Extra Helm install arguments (optional)
 #         --wait-timeout TIME    Timeout for helm install --wait (default: 15m)
@@ -60,7 +60,7 @@ cmd_validate() {
 
 cmd_install() {
     # Default values
-    local namespace="kube-system"
+    local namespace="coco-system"
     local values_file=""
     local extra_args=""
     local wait_timeout="15m"
@@ -71,7 +71,7 @@ cmd_install() {
         echo "Usage: $0 install RELEASE_NAME [OPTIONS]"
         echo ""
         echo "Options:"
-        echo "  --namespace NAME       Kubernetes namespace (default: kube-system)"
+        echo "  --namespace NAME       Kubernetes namespace (default: coco-system)"
         echo "  --values-file PATH     Path to values file (optional)"
         echo "  --extra-args ARGS      Extra Helm install arguments (optional)"
         echo "  --wait-timeout TIME    Timeout for helm install --wait (default: 15m)"

--- a/.github/scripts/k8s-deployment-verification.sh
+++ b/.github/scripts/k8s-deployment-verification.sh
@@ -11,7 +11,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 source "${SCRIPT_DIR}/common.sh"
 
 wait_daemonset() {
-    local namespace="kube-system" label="name=kata-as-coco-runtime" timeout="15m"
+    local namespace="coco-system" label="name=kata-as-coco-runtime" timeout="15m"
     
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -36,7 +36,7 @@ wait_daemonset() {
 }
 
 verify_daemonset() {
-    local namespace="kube-system" label="name=kata-as-coco-runtime"
+    local namespace="coco-system" label="name=kata-as-coco-runtime"
     
     while [ $# -gt 0 ]; do
         case "$1" in
@@ -73,7 +73,7 @@ verify_daemonset() {
 }
 
 show_logs() {
-    local namespace="kube-system" label="name=kata-as-coco-runtime" tail="50"
+    local namespace="coco-system" label="name=kata-as-coco-runtime" tail="50"
     
     while [ $# -gt 0 ]; do
         case "$1" in

--- a/.github/scripts/k8s-operations.sh
+++ b/.github/scripts/k8s-operations.sh
@@ -67,20 +67,20 @@ Categories & Commands:
   deployment wait-daemonset [OPTIONS]
       Wait for kata-deploy daemonset to become ready
       Options:
-        --namespace NAME          Namespace (default: kube-system)
+        --namespace NAME          Namespace (default: coco-system)
         --label SELECTOR          Label selector (default: name=kata-as-coco-runtime)
         --timeout TIME            Timeout (default: 15m)
 
   deployment verify-daemonset [OPTIONS]
       Verify daemonset status
       Options:
-        --namespace NAME          Namespace (default: kube-system)
+        --namespace NAME          Namespace (default: coco-system)
         --label SELECTOR          Label selector (default: name=kata-as-coco-runtime)
 
   deployment show-logs [OPTIONS]
       Show daemonset logs
       Options:
-        --namespace NAME          Namespace (default: kube-system)
+        --namespace NAME          Namespace (default: coco-system)
         --label SELECTOR          Label selector (default: name=kata-as-coco-runtime)
         --tail LINES              Number of lines (default: 50)
 

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -422,7 +422,7 @@ jobs:
         uses: ./.github/actions/install-chart
         with:
           release-name: ${{ steps.deployment-params.outputs.release-name }}
-          namespace: kube-system
+          namespace: coco-system
           values-file: ${{ steps.deployment-params.outputs.values-file }}
           extra-args: ${{ steps.helm-args.outputs.args }}
           wait-timeout: 15m
@@ -431,7 +431,7 @@ jobs:
         if: steps.should-run.outputs.should-run == 'true'
         uses: ./.github/actions/verify-deployment
         with:
-          namespace: kube-system
+          namespace: coco-system
           expected-runtime-classes: ${{ steps.deployment-params.outputs.expected-runtimeclasses }}
           daemonset-timeout: 15m
           daemonset-label: ${{ steps.deployment-params.outputs.daemonset-label }}
@@ -506,7 +506,7 @@ jobs:
           
           echo ""
           echo "=== DaemonSet status ==="
-          kubectl get daemonset -n kube-system
+          kubectl get daemonset -n coco-system
           
           echo ""
           echo "=== RuntimeClasses ==="
@@ -584,12 +584,12 @@ jobs:
           
           echo ""
           echo "=== kata-deploy logs ==="
-          kubectl logs -n kube-system -l ${{ steps.deployment-params.outputs.daemonset-label }} --tail=200 --prefix=true || echo "No logs available"
+          kubectl logs -n coco-system -l ${{ steps.deployment-params.outputs.daemonset-label }} --tail=200 --prefix=true || echo "No logs available"
           
           if [ "${{ matrix.test-containerd-upgrade }}" == "true" ]; then
             echo ""
             echo "=== containerd-installer logs ==="
-            kubectl logs -n kube-system -l app.kubernetes.io/component=containerd-installer --tail=200 --prefix=true || echo "No logs available"
+            kubectl logs -n coco-system -l app.kubernetes.io/component=containerd-installer --tail=200 --prefix=true || echo "No logs available"
           fi
           
           echo ""
@@ -608,7 +608,7 @@ jobs:
           fi
           
           echo "🗑️  Uninstalling chart: ${RELEASE_NAME}..."
-          helm uninstall ${RELEASE_NAME} -n kube-system --wait --timeout 5m || true
+          helm uninstall ${RELEASE_NAME} -n coco-system --wait --timeout 5m || true
           
           # For containerd upgrade tests, verify rollback
           if [ "${{ matrix.test-containerd-upgrade }}" == "true" ]; then
@@ -620,7 +620,7 @@ jobs:
             ELAPSED=0
             CLEANUP_JOB=""
             while [ $ELAPSED -lt $TIMEOUT ]; do
-              CLEANUP_JOB=$(kubectl get jobs -n kube-system -l app.kubernetes.io/component=containerd-cleanup -o name 2>/dev/null | head -1 || echo "")
+              CLEANUP_JOB=$(kubectl get jobs -n coco-system -l app.kubernetes.io/component=containerd-cleanup -o name 2>/dev/null | head -1 || echo "")
               if [ -n "${CLEANUP_JOB}" ]; then
                 echo "✅ Found cleanup job after ${ELAPSED}s: ${CLEANUP_JOB}"
                 break
@@ -631,14 +631,14 @@ jobs:
             
             if [ -n "${CLEANUP_JOB}" ]; then
               # Wait for the cleanup job to complete
-              if kubectl wait --for=condition=complete --timeout=120s "${CLEANUP_JOB}" -n kube-system 2>/dev/null; then
+              if kubectl wait --for=condition=complete --timeout=120s "${CLEANUP_JOB}" -n coco-system 2>/dev/null; then
                 echo "✅ Cleanup job completed successfully"
                 echo "📋 Cleanup job logs:"
-                kubectl logs -n kube-system "${CLEANUP_JOB}" --tail=50 || true
+                kubectl logs -n coco-system "${CLEANUP_JOB}" --tail=50 || true
               else
                 echo "⚠️  Cleanup job did not complete within timeout"
-                kubectl describe "${CLEANUP_JOB}" -n kube-system || true
-                kubectl logs -n kube-system "${CLEANUP_JOB}" --tail=100 || true
+                kubectl describe "${CLEANUP_JOB}" -n coco-system || true
+                kubectl logs -n coco-system "${CLEANUP_JOB}" --tail=100 || true
               fi
             else
               echo "⚠️  No cleanup job found after ${TIMEOUT}s"
@@ -683,10 +683,10 @@ jobs:
               echo "   Got:      ${AFTER_UNINSTALL_VERSION}"
               echo ""
               echo "Checking for cleanup job status:"
-              kubectl get jobs -n kube-system -l app.kubernetes.io/component=containerd-cleanup || true
+              kubectl get jobs -n coco-system -l app.kubernetes.io/component=containerd-cleanup || true
               echo ""
               echo "Checking for cleanup job logs:"
-              kubectl logs -n kube-system -l app.kubernetes.io/component=containerd-cleanup --tail=100 || true
+              kubectl logs -n coco-system -l app.kubernetes.io/component=containerd-cleanup --tail=100 || true
               exit 1
             fi
           fi
@@ -694,7 +694,7 @@ jobs:
           echo ""
           echo "🔍 Verifying cleanup..."
           echo "Remaining pods:"
-          kubectl get pods -n kube-system -l app.kubernetes.io/instance=${RELEASE_NAME} || echo "No pods found"
+          kubectl get pods -n coco-system -l app.kubernetes.io/instance=${RELEASE_NAME} || echo "No pods found"
           
           echo ""
           echo "Remaining RuntimeClasses:"
@@ -703,7 +703,7 @@ jobs:
           if [ "${{ matrix.test-containerd-upgrade }}" == "true" ]; then
             echo ""
             echo "Remaining cleanup jobs:"
-            kubectl get jobs -n kube-system -l app.kubernetes.io/component=containerd-cleanup || echo "No cleanup jobs found"
+            kubectl get jobs -n coco-system -l app.kubernetes.io/component=containerd-cleanup || echo "No cleanup jobs found"
           fi
 
       - name: Test normal pod after cleanup

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -120,25 +120,25 @@ jobs:
           # x86_64 (Intel/AMD)
           helm install coco oci://ghcr.io/${{ github.repository_owner }}/charts/confidential-containers \\
             --version ${VERSION} \\
-            --namespace kube-system
+            --namespace coco-system
           
           # s390x (IBM Z)
           helm install coco oci://ghcr.io/${{ github.repository_owner }}/charts/confidential-containers \\
             --version ${VERSION} \\
             -f https://raw.githubusercontent.com/${{ github.repository }}/v${VERSION}/values/kata-s390x.yaml \\
-            --namespace kube-system
+            --namespace coco-system
           
           # aarch64 (ARM64)
           helm install coco oci://ghcr.io/${{ github.repository_owner }}/charts/confidential-containers \\
             --version ${VERSION} \\
             -f https://raw.githubusercontent.com/${{ github.repository }}/v${VERSION}/values/kata-aarch64.yaml \\
-            --namespace kube-system
+            --namespace coco-system
           
           # peer-pods (remote)
           helm install coco oci://ghcr.io/${{ github.repository_owner }}/charts/confidential-containers \\
             --version ${VERSION} \\
             -f https://raw.githubusercontent.com/${{ github.repository }}/v${VERSION}/values/kata-remote.yaml \\
-            --namespace kube-system
+            --namespace coco-system
           \`\`\`
           
           ## What's Included
@@ -234,7 +234,7 @@ jobs:
           🚀 Installation Command:
              helm install coco oci://ghcr.io/${{ github.repository_owner }}/charts/confidential-containers \\
                --version ${VERSION} \\
-               --namespace kube-system
+               --namespace coco-system
           
           ✅ Chart package available as release artifact
           ✅ Chart pushed to GitHub Container Registry

--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -19,7 +19,7 @@ The chart is published to the OCI registry at `oci://ghcr.io/confidential-contai
 
 ```bash
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 **What you get:**
@@ -33,7 +33,7 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
 ```bash
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-s390x.yaml \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 **What you get:**
@@ -45,7 +45,7 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
 ```bash
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-aarch64.yaml \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 **What you get:**
@@ -56,7 +56,7 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
 ```bash
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-remote.yaml \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 **What you get:**
@@ -75,18 +75,18 @@ cd charts
 ./scripts/update-dependencies.sh
 
 # Install for your architecture
-helm install coco . --namespace kube-system  # x86_64
+helm install coco . --namespace coco-system  # x86_64
 # OR
-helm install coco . -f values/kata-s390x.yaml --namespace kube-system  # s390x
+helm install coco . -f values/kata-s390x.yaml --namespace coco-system  # s390x
 # OR
-helm install coco . -f values/kata-aarch64.yaml --namespace kube-system  # aarch64
+helm install coco . -f values/kata-aarch64.yaml --namespace coco-system  # aarch64
 ```
 
 ## Verify Installation
 
 ```bash
 # Check the daemonset is running
-kubectl get daemonset -n kube-system
+kubectl get daemonset -n coco-system
 
 # List available RuntimeClasses
 kubectl get runtimeclass
@@ -143,14 +143,14 @@ You can combine architecture values files (with `-f`) with `--set` flags for cus
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.env.debug=true \
-  --namespace kube-system
+  --namespace coco-system
 
 # For s390x
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-s390x.yaml \
   --set kata-as-coco-runtime.env.debug=true \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 ### Deploy on Specific Nodes (Node Selector)
@@ -161,14 +161,14 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.nodeSelector."node-role\.kubernetes\.io/worker"="" \
-  --namespace kube-system
+  --namespace coco-system
 
 # s390x - deploy on nodes with custom label
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-s390x.yaml \
   --set kata-as-coco-runtime.nodeSelector."confidential-computing"="enabled" \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 ### Custom Image Pull Policy
@@ -180,7 +180,7 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-s390x.yaml \
   --set kata-as-coco-runtime.imagePullPolicy=IfNotPresent \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 ### Private Registry with Image Pull Secrets
@@ -193,14 +193,14 @@ kubectl create secret docker-registry my-registry-secret \
   --docker-server=my-registry.example.com \
   --docker-username=myuser \
   --docker-password=mypassword \
-  --namespace kube-system
+  --namespace coco-system
 
 # Reference it in the installation
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-s390x.yaml \
   --set-json 'kata-as-coco-runtime.imagePullSecrets=[{"name":"my-registry-secret"}]' \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 ### Different Kubernetes Distribution
@@ -211,14 +211,14 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.k8sDistribution=k3s \
-  --namespace kube-system
+  --namespace coco-system
 
 # For RKE2 on s390x
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-s390x.yaml \
   --set kata-as-coco-runtime.k8sDistribution=rke2 \
-  --namespace kube-system
+  --namespace coco-system
 
 # Supported: k8s (default), k3s, rke2, k0s, microk8s
 
@@ -235,7 +235,7 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
   --set kata-as-coco-runtime.env.debug=true \
   --set kata-as-coco-runtime.nodeSelector."node-role\.kubernetes\.io/worker"="" \
   --set kata-as-coco-runtime.k8sDistribution=k3s \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 ### Custom Shims (x86_64 example - SNP and TDX only)
@@ -244,7 +244,7 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.env.shims="qemu-snp qemu-tdx qemu-coco-dev" \
   --set kata-as-coco-runtime.env.snapshotterHandlerMapping="qemu-snp:nydus\,qemu-tdx:nydus\,qemu-coco-dev:nydus" \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 ### Custom Values File
@@ -272,7 +272,7 @@ Then install:
 ```bash
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f my-values.yaml \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 ## Advanced Configuration
@@ -291,7 +291,7 @@ Set which shim to use by default when none is specified in pod annotations (by d
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.env.defaultShim=qemu-tdx \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 #### Custom Installation Path
@@ -301,7 +301,7 @@ Override the installation prefix (by default, kata-deploy uses its built-in defa
 ```bash
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.env.installationPrefix=/opt/custom-kata \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 #### Multiple Installations
@@ -314,7 +314,7 @@ Enable multiple Kata installations on the same node with a suffix:
 
 helm install coco-test oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.env.multiInstallSuffix=/opt/kata-PR12345 \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 #### Custom Image Tag
@@ -324,7 +324,7 @@ Override the image tag (by default uses chart's appVersion):
 ```bash
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.image.tag=3.21.0 \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 #### RuntimeClass Management
@@ -337,13 +337,13 @@ Control creation of Kubernetes RuntimeClass resources:
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.env.createRuntimeClasses=false \
-  --namespace kube-system
+  --namespace coco-system
 
 # Create the default Kubernetes RuntimeClass
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.env.createDefaultRuntimeClass=true \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 #### Hypervisor Annotations
@@ -353,7 +353,7 @@ Enable specific annotations to be passed when launching containers:
 ```bash
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.env.allowedHypervisorAnnotations="io.katacontainers.*" \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 #### Proxy Configuration for Kata Agent
@@ -366,20 +366,20 @@ Configure proxy settings for the Kata agent:
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.env.agentHttpsProxy="https://proxy.example.com:8080" \
-  --namespace kube-system
+  --namespace coco-system
 
 # Set NO_PROXY
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.env.agentNoProxy="localhost,127.0.0.1,.svc" \
-  --namespace kube-system
+  --namespace coco-system
 
 # Combine both
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set kata-as-coco-runtime.env.agentHttpsProxy="https://proxy.example.com:8080" \
   --set kata-as-coco-runtime.env.agentNoProxy="localhost,127.0.0.1" \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 ## Upgrading
@@ -389,7 +389,7 @@ Upgrades are not yet supported
 ## Uninstalling
 
 ```bash
-helm uninstall coco --namespace kube-system
+helm uninstall coco --namespace coco-system
 ```
 
 ## Troubleshooting
@@ -397,7 +397,7 @@ helm uninstall coco --namespace kube-system
 ### Check Helm Release Status
 
 ```bash
-helm status coco -n kube-system
+helm status coco -n coco-system
 ```
 
 ### View Helm Release Details
@@ -406,21 +406,21 @@ helm status coco -n kube-system
 
 # View all release information
 
-helm get all coco -n kube-system
+helm get all coco -n coco-system
 
 # View rendered manifests
 
-helm get manifest coco -n kube-system
+helm get manifest coco -n coco-system
 
 # View values used
 
-helm get values coco -n kube-system
+helm get values coco -n coco-system
 ```
 
 ### Check DaemonSet Logs
 
 ```bash
-kubectl logs -n kube-system -l name=kata-deploy
+kubectl logs -n coco-system -l name=kata-deploy
 ```
 
 ### Verify RuntimeClasses
@@ -446,14 +446,14 @@ helm show readme oci://ghcr.io/confidential-containers/charts/confidential-conta
 ### List Installed Charts
 
 ```bash
-helm list -n kube-system
+helm list -n coco-system
 ```
 
 ## Important Notes
 
 1. **Comma Escaping:** When using `--set` with values containing commas, escape them with `\,`
 2. **Node Selectors:** When setting node selectors with dots in the key, escape them: `node-role\.kubernetes\.io/worker`
-3. **Namespace:** All examples use `kube-system` namespace. Adjust as needed for your environment.
+3. **Namespace:** All examples use `coco-system` namespace. Adjust as needed for your environment.
 4. **Architecture:** The default architecture is x86_64. Other architectures must be explicitly specified.
 
 ## Next Steps

--- a/README.md
+++ b/README.md
@@ -12,16 +12,16 @@ To use the latest kata-containers build from the main branch for CI testing, use
 
 ```bash
 # Production installation
-helm install coco . --namespace kube-system
+helm install coco . --namespace coco-system
 
 # CI testing with latest build
-helm install coco . -f values/profile-ci.yaml --namespace kube-system
+helm install coco . -f values/profile-ci.yaml --namespace coco-system
 
 # CI testing with custom k8s distribution (e.g., rke2)
 helm install coco . \
     -f values/profile-ci.yaml \
     --set kata-as-coco-runtime.k8sDistribution=rke2 \
-    --namespace kube-system
+    --namespace coco-system
 ```
 
 **Goal:** Replace the [Confidential Containers Operator](https://github.com/confidential-containers/operator) as the primary deployment method by the **0.18.0 release**.
@@ -57,28 +57,28 @@ The chart is published to `oci://ghcr.io/confidential-containers/charts/confiden
 **Basic installation for x86_64:**
 ```bash
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 **For s390x:**
 ```bash
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-s390x.yaml \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 **For aarch64:**
 ```bash
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-aarch64.yaml \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 **For peer-pods:**
 ```bash
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-remote.yaml \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 ### Detailed Installation Instructions
@@ -163,7 +163,7 @@ The available RuntimeClasses depend on the architecture:
 
 # Check the daemonset
 
-kubectl get daemonset -n kube-system
+kubectl get daemonset -n coco-system
 
 # List available RuntimeClasses
 
@@ -259,14 +259,14 @@ The chart supports installing a custom containerd binary from a tarball before d
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --set customContainerd.enabled=true \
   --set customContainerd.tarballUrl=https://example.com/containerd-1.7.0-linux-amd64.tar.gz \
-  --namespace kube-system
+  --namespace coco-system
 
 # Install with custom containerd for s390x
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-s390x.yaml \
   --set customContainerd.enabled=true \
   --set customContainerd.tarballUrl=https://example.com/containerd-1.7.0-linux-s390x.tar.gz \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 **Example (Multi-Architecture/Heterogeneous Cluster):**
@@ -276,7 +276,7 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
   --set customContainerd.enabled=true \
   --set customContainerd.tarballUrls.amd64=https://example.com/containerd-1.7.0-linux-amd64.tar.gz \
   --set customContainerd.tarballUrls.arm64=https://example.com/containerd-1.7.0-linux-arm64.tar.gz \
-  --namespace kube-system
+  --namespace coco-system
 
 # Or using a custom values file
 cat <<EOF > custom-containerd.yaml
@@ -290,7 +290,7 @@ EOF
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f custom-containerd.yaml \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 **Important Notes:**
@@ -333,7 +333,7 @@ These files can be referenced directly via URL when installing from the OCI regi
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-s390x.yaml \
-  --namespace kube-system
+  --namespace coco-system
 ```
 
 ### How It Works
@@ -350,7 +350,7 @@ Support for upgrading is coming soon
 ## Uninstallation
 
 ```bash
-helm uninstall coco --namespace kube-system
+helm uninstall coco --namespace coco-system
 ```
 
 The uninstall command is the same regardless of whether you installed from the OCI registry or locally.

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -6,7 +6,7 @@ This directory contains helper scripts for managing the Confidential Containers 
 
 Most users don't need to run this command, because when installing from an OCI registry, Helm fetches dependencies automatically.
 
-If you are developing this chart and trying to install local changes (e.g., `helm install coco . --namespace kube-system`), you need to download the dependency charts first:
+If you are developing this chart and trying to install local changes (e.g., `helm install coco . --namespace coco-system`), you need to download the dependency charts first:
 
 ```bash
 helm dependency update

--- a/values/profile-ci.yaml
+++ b/values/profile-ci.yaml
@@ -4,10 +4,10 @@
 # from the kata-containers CI pipeline instead of stable releases.
 #
 # Usage:
-#   helm install coco . -f values/kata-remote.yaml -f values/profile-ci.yaml --namespace kube-system
+#   helm install coco . -f values/kata-remote.yaml -f values/profile-ci.yaml --namespace coco-system
 #
 # For different architectures, combine with architecture-specific values:
-#   helm install coco . -f values/kata-s390x.yaml -f values/profile-ci.yaml --namespace kube-system
+#   helm install coco . -f values/kata-s390x.yaml -f values/profile-ci.yaml --namespace coco-system
 #
 
 kata-as-coco-runtime:


### PR DESCRIPTION
It's bad practice to install anything in the kube-system namespace, unless it actually needs to run there - and users may install coco in kube-system simply because the documentation defaults to kube-system.

This makes sense from a security point of view, and also from a maintenance point of view, should CoCo blow up it's at least confined to it's own namespace making containment and cleanup a lot easier.

Fixes: #24