### PR TITLE
readme: Mark Container Runtimes support as ✅

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -6,7 +6,7 @@ Get started with Confidential Containers on your architecture in just a few comm
 
 - Kubernetes 1.24+
 - Helm 3.8+
-- Container runtime with RuntimeClass support (containerd or CRI-O)
+- Container runtime with RuntimeClass support (containerd)
 - Hardware with TEE support (for production use)
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This chart includes:
 
 - Kubernetes 1.24+
 - Helm 3.8+
-- Container runtime with RuntimeClass support (containerd or CRI-O)
+- Container runtime with RuntimeClass support (containerd)
 - Hardware with TEE support
 
 ## Installation
@@ -396,7 +396,7 @@ See the [Confidential Containers contributing guide](https://github.com/confiden
 | Aspect | Coverage | Details |
 |--------|----------|---------|
 | **Kubernetes Distributions** | ✅ | k3s, k0s, rke2, microk8s, kubeadm |
-| **Container Runtimes** | ⚠️ | containerd, CRI-O tests are not yet ready |
+| **Container Runtimes** | ✅ | containerd |
 | **Deployment Types** | ✅ | Standard (CoCo releases), CI (Kata Containers latest) |
 | **Image Pull Modes** | ✅ | nydus-snapshotter, experimental-force-guest-pull |
 | **Special Tests** | ✅ | Custom containerd |


### PR DESCRIPTION
CRI-O was never tested by the Confidential Containers Operator and may be added in the future as a feature for this repo.

However, as it's not a parity situation, we can safely mark the Container Runtimes support as ✅, and let someone expand it once more Container Runtimes are added to the test matrix.