### PR TITLE
docs: clarify Helm chart as official deployment method

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -2,6 +2,10 @@
 
 Get started with Confidential Containers on your architecture in just a few commands!
 
+> **📢 This Helm chart is the official way to deploy Confidential Containers.**
+>
+> The [CoCo Operator](https://github.com/confidential-containers/operator) is deprecated. Please use this Helm chart for all new deployments.
+
 ## Prerequisites
 
 - Kubernetes 1.24+
@@ -447,6 +451,16 @@ helm list -n coco-system
 
 - **Advanced Configuration:** See `examples-custom-values.yaml`
 - **Full Documentation:** See `README.md`
+
+## Migrating from the Operator
+
+If you're currently using the CoCo Operator:
+
+1. Uninstall the operator following its documentation
+2. Install this Helm chart using the commands above
+3. Your RuntimeClasses will be recreated automatically
+
+The Helm chart provides equivalent functionality with simpler configuration.
 
 ## Getting Help
 

--- a/README.md
+++ b/README.md
@@ -2,11 +2,25 @@
 
 Umbrella Helm chart for Confidential Containers. This chart deploys kata-containers runtime with confidential computing support for TEE technologies.
 
-## Project Status
+> **📢 This Helm chart is now the official and recommended way to deploy Confidential Containers.**
+>
+> The [Confidential Containers Operator](https://github.com/confidential-containers/operator) is **deprecated** and will no longer receive updates. All new deployments should use this Helm chart.
 
-⚠️ **Early Stage Development** - This Helm chart is in its primary development phase as part of the effort to provide an alternative deployment method for Confidential Containers.
+## Migration from Operator
 
-⚠️ **CI Testing:**
+If you're currently using the CoCo Operator, we recommend migrating to this Helm chart:
+
+1. **Uninstall the Operator**: Follow the operator's uninstall instructions
+2. **Install via Helm**: Use the installation commands below
+3. **Update your workflows**: Replace operator CRDs with Helm values
+
+The Helm chart provides the same functionality with:
+- Simpler installation and configuration
+- Better integration with GitOps workflows
+- Faster updates aligned with kata-containers releases
+- Support for multiple Kubernetes distributions (k3s, k0s, rke2, microk8s, kubeadm)
+
+## CI Testing
 
 To use the latest kata-containers build from the main branch for CI testing, use the CI profile:
 
@@ -24,14 +38,6 @@ helm install coco . \
     --namespace coco-system \
     --create-namespace
 ```
-
-**Goal:** Replace the [Confidential Containers Operator](https://github.com/confidential-containers/operator) as the primary deployment method by the **0.18.0 release**.
-
-**Current Focus:**
-- ✅ Core functionality and E2E testing
-- ✅ Multi k8s distribution support (eg, k0s, k3s, microk8s, kubeadm, rke2 support)
-- 🔄 Feature parity with Operator
-- 📋 See [Test Coverage & Roadmap](#test-coverage--roadmap) below for detailed progress
 
 ## Overview
 
@@ -373,12 +379,13 @@ See the [Confidential Containers contributing guide](https://github.com/confiden
 | **Image Pull Modes** | ✅ | nydus-snapshotter, experimental-force-guest-pull |
 | **Special Tests** | ✅ | Custom containerd |
 
-### Roadmap to 0.18.0
+### Roadmap
 
-- ✅ **Phase 1** (Current) - Comprehensive E2E test coverage, unified actions
-- 🔄 **Phase 2** - Feature parity verification, edge case testing, peer-pods support
-- 📋 **Phase 3** - Operator deprecation notice, migration guide
-- 📋 **Phase 4 (0.18.0)** - Operator replacement as primary method
+- ✅ **Phase 1** - Comprehensive E2E test coverage, unified actions
+- ✅ **Phase 2** - Feature parity verification, edge case testing
+- ✅ **Phase 3** - Operator deprecation, migration guide
+- 🔄 **Phase 4** - Peer-pods support, additional platform testing
+- 📋 **Phase 5** - Production hardening, documentation improvements
 
 ## License
 


### PR DESCRIPTION
The Confidential Containers Operator is now deprecated. Update documentation to make it clear that:

- This Helm chart is the official and recommended way to deploy CoCo
- The Operator will no longer receive updates
- Users should migrate from the Operator to this Helm chart

Add migration guidance and update the roadmap to reflect current status.