### PR TITLE
workflows: Install yq regardless of deployment-type

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -283,13 +283,17 @@ jobs:
           echo "Detected architecture: ${ARCH}"
           echo "ARCH=${ARCH}" >> $GITHUB_ENV
 
-      - name: Install yq (for CI tests)
-        if: steps.should-run.outputs.should-run == 'true' && matrix.environment.deployment-type == 'ci'
+      - name: Install yq
+        if: steps.should-run.outputs.should-run == 'true'
         run: |
-          echo "📦 Installing yq for chart version override..."
-          sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH}
-          sudo chmod +x /usr/local/bin/yq
-          yq --version
+          if command -v yq >/dev/null 2>&1; then
+            echo "✅ yq already installed, skipping installation"
+          else
+            echo "📦 Installing yq for chart version override..."
+            sudo wget -qO /usr/local/bin/yq https://github.com/mikefarah/yq/releases/latest/download/yq_linux_${ARCH}
+            sudo chmod +x /usr/local/bin/yq
+            yq --version
+          fi
 
       - name: Update Helm dependencies
         if: steps.should-run.outputs.should-run == 'true'


### PR DESCRIPTION
Currently, yq is only installed when the deployment type is `ci`. For the `standard` deployment type, yq is still used in the `Determine deployment parameters` step.
Therefore, yq should be installed regardless of the configured deployment type.

This PR ensures that yq is installed on the runner if it is not already present.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>