### PR TITLE
workflows: Fetch K8S version in GitHub runners and propagate it

### DIFF
--- a/.github/actions/setup-k8s/action.yaml
+++ b/.github/actions/setup-k8s/action.yaml
@@ -21,6 +21,10 @@ inputs:
     description: 'Command to run (setup or cleanup)'
     required: false
     default: 'setup'
+  k8s-version:
+    description: 'Kubernetes version (e.g., v1.29) - if not provided, will be fetched'
+    required: false
+    default: ''
 runs:
   using: 'composite'
   steps:
@@ -28,6 +32,7 @@ runs:
       shell: bash
       env:
         GH_TOKEN: ${{ github.token }}
+        K8S_VERSION: ${{ inputs.k8s-version }}
       run: |
         case "${{ inputs.distribution }}" in
           kubeadm)

--- a/.github/scripts/k8s-setup.sh
+++ b/.github/scripts/k8s-setup.sh
@@ -79,8 +79,13 @@ install_crio() {
         sudo apt-get purge -y cri-o cri-tools || true
     fi
 
-    local k8s_ver=$(curl -Ls https://dl.k8s.io/release/stable.txt | cut -d. -f-2)
-    [ -z "$k8s_ver" ] && { echo "❌ Failed to determine K8s version"; exit 1; }
+    local k8s_ver="${K8S_VERSION:-}"
+    if [ -z "$k8s_ver" ]; then
+        echo "🔍 K8S_VERSION not set, fetching from upstream..."
+        k8s_ver=$(curl -Ls https://dl.k8s.io/release/stable.txt | cut -d. -f-2)
+        [ -z "$k8s_ver" ] && { echo "❌ Failed to determine K8s version"; exit 1; }
+    fi
+    echo "✅ Using Kubernetes version: $k8s_ver"
 
     local crio_ver="$k8s_ver"
     if ! curl -fsSL --head "https://download.opensuse.org/repositories/isv:/cri-o:/stable:/${crio_ver}/deb/Release.key" >/dev/null 2>&1; then
@@ -109,7 +114,14 @@ EOF
 
 install_kubeadm_components() {
     echo "📦 Installing Kubernetes components..."
-    local k8s_ver=$(curl -Ls https://dl.k8s.io/release/stable.txt | cut -d. -f-2)
+    local k8s_ver="${K8S_VERSION:-}"
+    if [ -z "$k8s_ver" ]; then
+        echo "🔍 K8S_VERSION not set, fetching from upstream..."
+        k8s_ver=$(curl -Ls https://dl.k8s.io/release/stable.txt | cut -d. -f-2)
+        [ -z "$k8s_ver" ] && { echo "❌ Failed to determine K8s version"; exit 1; }
+    fi
+    echo "✅ Using Kubernetes version: $k8s_ver"
+
     curl -fsSL "https://pkgs.k8s.io/core:/stable:/${k8s_ver}/deb/Release.key" | sudo gpg --batch --yes --no-tty --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
     echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${k8s_ver}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
 

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -28,11 +28,24 @@ jobs:
     outputs:
       kata-deploy-version-changed: ${{ steps.check-appversion.outputs.changed }}
       templates-changed: ${{ steps.check-templates.outputs.changed }}
+      k8s-version: ${{ steps.get-k8s-version.outputs.version }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Get Kubernetes version
+        id: get-k8s-version
+        run: |
+          echo "🔍 Fetching latest stable Kubernetes version..."
+          K8S_VERSION=$(curl -Ls https://dl.k8s.io/release/stable.txt | cut -d. -f-2)
+          if ! echo "$K8S_VERSION" | grep -qE '^v[0-9]+\.[0-9]+(\.[0-9]+)?$'; then
+            echo "❌ Invalid Kubernetes version format: $K8S_VERSION (expected pattern: v1.35 or v1.35.0)"
+            exit 1
+          fi
+          echo "✅ Kubernetes version: $K8S_VERSION"
+          echo "version=$K8S_VERSION" >> $GITHUB_OUTPUT
 
       - name: Check if kata-deploy dependency version changed
         id: check-appversion
@@ -226,6 +239,7 @@ jobs:
         with:
           distribution: kubeadm
           container-runtime: containerd
+          k8s-version: ${{ needs.check-changes.outputs.k8s-version }}
           runtime-version: latest
       
       - name: Setup Kubernetes cluster (kubeadm with containerd 1.7)
@@ -235,6 +249,7 @@ jobs:
           distribution: kubeadm
           container-runtime: containerd
           runtime-version: "1.7"
+          k8s-version: ${{ needs.check-changes.outputs.k8s-version }}
       
       - name: Setup Kubernetes cluster (kubeadm with CRI-O)
         if: steps.should-run.outputs.should-run == 'true' && matrix.environment.k8s-distro == 'kubeadm-crio'
@@ -242,6 +257,7 @@ jobs:
         with:
           distribution: kubeadm
           container-runtime: crio
+          k8s-version: ${{ needs.check-changes.outputs.k8s-version }}
 
       - name: Determine k8s distribution name
         if: steps.should-run.outputs.should-run == 'true'


### PR DESCRIPTION
The following error was observed intermittently on s390x runners:

```
curl: (3) URL rejected: Malformed input to a URL function
gpg: no valid OpenPGP data found.
```

This was caused by intermittent routing issues on the runners, which can lead to timeouts and an empty version being used in scripts.

Fetch the Kubernetes version on GitHub-hosted runners and propagate it to the scripts to avoid this failure.

Signed-off-by: Hyounggyu Choi <Hyounggyu.Choi@ibm.com>