### PR TITLE
feat: add NVIDIA GPU support with TEE protection

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -29,7 +29,8 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
 **What you get:**
 - AMD SEV-SNP support (kata-qemu-snp)
 - Intel TDX support (kata-qemu-tdx)
-- NVIDIA GPU variants
+- NVIDIA GPU with SEV-SNP (kata-qemu-nvidia-gpu-snp)
+- NVIDIA GPU with TDX (kata-qemu-nvidia-gpu-tdx)
 - Development runtime (kata-qemu-coco-dev)
 
 #### For s390x (IBM Z)
@@ -53,7 +54,7 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
 ```
 
 **What you get:**
-- remote runtime (peer-pods / Cloud API Adaptopr integration)
+- remote runtime (peer-pods / Cloud API Adaptor integration)
 
 ### Installing from Local Repository (Development)
 
@@ -473,7 +474,12 @@ The Helm chart provides equivalent functionality with simpler configuration.
 ### x86_64
 
 - Requires AMD or Intel processors with SEV-SNP or TDX support
-- GPU variants require NVIDIA GPU with appropriate drivers
+
+### x86_64 with NVIDIA GPU
+
+- Requires NVIDIA GPU
+- Use `kata-qemu-nvidia-gpu-snp` for AMD SEV-SNP + GPU
+- Use `kata-qemu-nvidia-gpu-tdx` for Intel TDX + GPU
 
 ### s390x
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ This chart includes:
 ### Quick Start
 
 The chart is published to `oci://ghcr.io/confidential-containers/charts/confidential-containers` and supports multiple architectures:
-- **x86_64**: Intel and AMD processors (default)
+- **x86_64**: Intel and AMD processors (default), includes NVIDIA GPU support
 - **s390x**: IBM Z mainframes
 - **peer-pods**: architecture independent
 
@@ -65,6 +65,8 @@ The chart is published to `oci://ghcr.io/confidential-containers/charts/confiden
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
   --namespace coco-system
 ```
+
+This includes both standard TEE shims (snp, tdx, coco-dev) and NVIDIA GPU shims (nvidia-gpu-snp, nvidia-gpu-tdx) by default.
 
 **For s390x:**
 ```bash
@@ -135,6 +137,8 @@ The available RuntimeClasses depend on the architecture:
 - `kata-qemu-coco-dev-runtime-rs` - Development/testing runtime (Rust-based)
 - `kata-qemu-snp` - AMD SEV-SNP
 - `kata-qemu-tdx` - Intel TDX
+- `kata-qemu-nvidia-gpu-snp` - NVIDIA GPU with AMD SEV-SNP protection
+- `kata-qemu-nvidia-gpu-tdx` - NVIDIA GPU with Intel TDX protection
 
 #### s390x
 
@@ -294,7 +298,7 @@ The Helm chart supports multiple architectures with appropriate TEE technology s
 ### Architecture-Specific Values Files
 
 Architecture-specific kata runtime configurations are organized in the `values/` directory:
-- **x86_64** - Default configuration in `values.yaml` (Intel/AMD platforms)
+- **x86_64** - Default configuration in `values.yaml` (Intel/AMD platforms, includes NVIDIA GPU support)
 - `values/kata-s390x.yaml` - For IBM Z mainframes
 - `values/kata-remote.yaml` - For peer-pods
 

--- a/values.yaml
+++ b/values.yaml
@@ -81,10 +81,6 @@ kata-as-coco-runtime:
   k8sDistribution: k8s
   debug: false
 
-  env:
-    # Set default shim for backward compatibility (structured format takes precedence)
-    defaultShim: "qemu-snp"
-
   # Deploy TEE-enabled runtime shims for x86_64
   # For other architectures, use the appropriate values file:
   #   - values/kata-s390x.yaml for IBM Z
@@ -150,6 +146,34 @@ kata-as-coco-runtime:
       containerd:
         snapshotter: nydus
         forceGuestPull: false
+      crio:
+        guestPull: true
+      agent:
+        httpsProxy: ""
+        noProxy: ""
+
+    # NVIDIA GPU shims with TEE protection
+    # These use experimental-force-guest-pull to match kata-containers configuration
+    qemu-nvidia-gpu-snp:
+      enabled: true
+      supportedArches:
+        - amd64
+      allowedHypervisorAnnotations: []
+      containerd:
+        forceGuestPull: true
+      crio:
+        guestPull: true
+      agent:
+        httpsProxy: ""
+        noProxy: ""
+
+    qemu-nvidia-gpu-tdx:
+      enabled: true
+      supportedArches:
+        - amd64
+      allowedHypervisorAnnotations: []
+      containerd:
+        forceGuestPull: true
       crio:
         guestPull: true
       agent:


### PR DESCRIPTION
Add NVIDIA GPU shims with TEE protection to the default values.yaml:
- kata-qemu-nvidia-gpu-snp: GPU with AMD SEV-SNP protection
- kata-qemu-nvidia-gpu-tdx: GPU with Intel TDX protection

Update README.md and QUICKSTART.md to document these RuntimeClasses
as part of the standard x86_64 installation.