### PR TITLE
kata: Bump to 3.25.0 release

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,6 +15,6 @@ maintainers:
 dependencies:
   - name: kata-deploy
     alias: kata-as-coco-runtime
-    version: "3.24.0"
+    version: "3.25.0"
     repository: "oci://ghcr.io/kata-containers/kata-deploy-charts"
     condition: kata-as-coco-runtime.enabled


### PR DESCRIPTION
For more details on the Kata Containers 3.25.0 release, please, check: https://github.com/kata-containers/kata-containers/releases/tag/3.25.0