### PR TITLE
Prepare release 0.18.0

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: kata-deploy
   repository: oci://ghcr.io/kata-containers/kata-deploy-charts
-  version: 3.24.0
-digest: sha256:5061ddd48fe1b41ce52fc671561053a3d72898dccd91c028215ab9aec9abf765
-generated: "2026-01-10T20:05:56.98513667+01:00"
+  version: 3.25.0
+digest: sha256:fc9ff680dad241cd96db9c05e46ee1e0ad2ee08decf24b577a7463dbd64e0142
+generated: "2026-01-20T07:03:42.872518731-08:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -5,9 +5,9 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: "0.17.1"
+version: "0.18.0"
 # This is the version number of the application being deployed.
-appVersion: "0.17.1"
+appVersion: "0.18.0"
 maintainers:
   - name: Confidential Containers Community
     url: https://github.com/confidential-containers


### PR DESCRIPTION
Update kata-deploy dependency to 3.25.0

Changes:
- Chart version: 0.18.0
- kata-deploy version: 3.25.0
- Updated Chart.lock

This is an automated commit created by scripts/prepare-release.sh

cc @fidencio 