### PR TITLE
Fix RuntimeClass leaks when using Helm value overrides

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -199,6 +199,30 @@ kata-as-coco-runtime:
     qemu-runtime-rs:
       enabled: false
 
+    qemu-snp-runtime-rs:
+      enabled: false
+
+    qemu-tdx-runtime-rs:
+      enabled: false
+
+    qemu-cca:
+      enabled: false
+
+    qemu-nvidia-gpu:
+      enabled: false
+
+    qemu-se:
+      enabled: false
+
+    qemu-se-runtime-rs:
+      enabled: false
+
+    stratovirt:
+      enabled: false
+
+    remote:
+      enabled: false
+
   # RuntimeClasses configuration
   runtimeClasses:
     enabled: true

--- a/values/kata-alibabacloud-tdx.yaml
+++ b/values/kata-alibabacloud-tdx.yaml
@@ -69,6 +69,12 @@ kata-as-coco-runtime:
     qemu-nvidia-gpu-snp:
       enabled: false
 
+    qemu-snp-runtime-rs:
+      enabled: false
+
+    qemu-tdx-runtime-rs:
+      enabled: false
+
   # RuntimeClasses configuration
   runtimeClasses:
     enabled: true

--- a/values/kata-remote.yaml
+++ b/values/kata-remote.yaml
@@ -45,3 +45,24 @@ kata-as-coco-runtime:
 
     qemu-runtime-rs:
       enabled: false
+
+    qemu-snp-runtime-rs:
+      enabled: false
+
+    qemu-tdx-runtime-rs:
+      enabled: false
+
+    qemu-nvidia-gpu:
+      enabled: false
+
+    qemu-nvidia-gpu-snp:
+      enabled: false
+
+    qemu-nvidia-gpu-tdx:
+      enabled: false
+
+    qemu-cca:
+      enabled: false
+
+    stratovirt:
+      enabled: false

--- a/values/kata-s390x.yaml
+++ b/values/kata-s390x.yaml
@@ -97,6 +97,31 @@ kata-as-coco-runtime:
     qemu-runtime-rs:
       enabled: false
 
+    # Disable x86_64-only shims
+    qemu-snp:
+      enabled: false
+
+    qemu-tdx:
+      enabled: false
+
+    qemu-snp-runtime-rs:
+      enabled: false
+
+    qemu-tdx-runtime-rs:
+      enabled: false
+
+    qemu-nvidia-gpu:
+      enabled: false
+
+    qemu-nvidia-gpu-snp:
+      enabled: false
+
+    qemu-nvidia-gpu-tdx:
+      enabled: false
+
+    qemu-cca:
+      enabled: false
+
   # RuntimeClasses configuration
   runtimeClasses:
     enabled: true


### PR DESCRIPTION
The kata-deploy's `disableAll` option doesn't work with Helm's deep merge:  override files were getting shims from both parent and override instead of just the override.

Example: kata-s390x.yaml created 8 RuntimeClasses instead of 4 (leaked x86_64 shims).

Disabling this, while we don't find a better approach.