### PR TITLE
adding peerpods as dependency

### DIFF
--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -129,6 +129,8 @@ jobs:
       fail-fast: false
       matrix:
         environment: [
+          { runner: ubuntu-24.04, deployment-type: standard, k8s-distro: k3s,                       image-pull-mode: nydus,                         test-containerd-upgrade: false, shim: remote                   },
+          { runner: ubuntu-24.04, deployment-type: ci,       k8s-distro: k3s,                       image-pull-mode: nydus,                         test-containerd-upgrade: false, shim: remote                   },
           { runner: ubuntu-24.04, deployment-type: ci,       k8s-distro: k3s,                       image-pull-mode: nydus,                         test-containerd-upgrade: false, shim: qemu-coco-dev            },
           { runner: ubuntu-24.04, deployment-type: ci,       k8s-distro: k3s,                       image-pull-mode: experimental-force-guest-pull, test-containerd-upgrade: false, shim: qemu-coco-dev            },
           { runner: ubuntu-24.04, deployment-type: ci,       k8s-distro: k0s,                       image-pull-mode: nydus,                         test-containerd-upgrade: false, shim: qemu-coco-dev            },
@@ -291,6 +293,27 @@ jobs:
             --password-stdin
           echo "✅ Helm authenticated with ghcr.io"
 
+      - name: Install cert-manager (required for peerpods webhook)
+        if: steps.should-run.outputs.should-run == 'true' && matrix.environment.shim == 'remote'
+        run: |
+          echo "📦 Installing cert-manager..."
+          kubectl apply -f https://github.com/jetstack/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+          echo "⏳ Waiting for cert-manager deployments..."
+          kubectl wait --timeout=120s -n cert-manager deployment/cert-manager --for=condition=available
+          kubectl wait --timeout=120s -n cert-manager deployment/cert-manager-webhook --for=condition=available
+          kubectl wait --timeout=120s -n cert-manager deployment/cert-manager-cainjector --for=condition=available
+          echo "✅ cert-manager is ready"
+
+      - name: Label worker nodes (required for peerpods)
+        if: steps.should-run.outputs.should-run == 'true' && matrix.environment.shim == 'remote'
+        run: |
+          echo "🏷️ Labeling nodes with node.kubernetes.io/worker..."
+          for node in $(kubectl get nodes -o jsonpath='{.items[*].metadata.name}'); do
+            kubectl label node "$node" node.kubernetes.io/worker= --overwrite
+            echo "  Labeled: $node"
+          done
+          echo "✅ All nodes labeled"
+
       - name: Determine architecture
         if: steps.should-run.outputs.should-run == 'true'
         run: |
@@ -357,6 +380,21 @@ jobs:
             ARGS="${ARGS} --set kata-as-coco-runtime.snapshotter.setup=null --set kata-as-coco-runtime.shims.${SHIM}.containerd.snapshotter='' --set kata-as-coco-runtime.shims.${SHIM}.containerd.forceGuestPull=true"
           fi
           
+          # Add peerpods provider config (only for remote shim).
+          # Uses docker provider since it runs on standard GH runners.
+          # Provider values files (e.g. providers/docker.yaml) are bundled
+          # inside the peerpods subchart tgz and not directly accessible,
+          # so we pass the config inline via --set.
+          if [ "${{ matrix.environment.shim }}" == "remote" ]; then
+            ARGS="${ARGS} --set kata-as-coco-runtime.defaultShim.amd64=remote"
+            ARGS="${ARGS} --set peerpods.provider=docker"
+            # Docker provider requires the dev image (includes CGO bindings).
+            ARGS="${ARGS} --set peerpods.image.tag=dev-a5f492482236b9fc4a77088efe6b4c2159ae6a03"
+            ARGS="${ARGS} --set peerpods.providerConfigs.docker.DOCKER_HOST=unix:///var/run/docker.sock"
+            ARGS="${ARGS} --set peerpods.providerConfigs.docker.DOCKER_NETWORK_NAME=bridge"
+            ARGS="${ARGS} --set peerpods.providerConfigs.docker.DOCKER_PODVM_IMAGE=quay.io/confidential-containers/podvm-docker-image"
+          fi
+
           # Add containerd upgrade flags (only for containerd upgrade test)
           if [ "${{ matrix.environment.test-containerd-upgrade }}" == "true" ]; then
             ARGS="${ARGS} --set customContainerd.enabled=true --set customContainerd.tarballUrl=https://github.com/containerd/containerd/releases/download/v2.0.0/containerd-2.0.0-linux-${ARCH}.tar.gz"
@@ -378,18 +416,24 @@ jobs:
           
           # Detect architecture and select appropriate values file
           ARCH=$(uname -m)
-          case "$ARCH" in
-            x86_64)
-              VALUES_FILE="values.yaml"
-              ;;
-            s390x)
-              VALUES_FILE="values/kata-s390x.yaml"
-              ;;
-            *)
-              echo "❌ Unsupported architecture: $ARCH"
-              exit 1
-              ;;
-          esac
+          SHIM="${{ matrix.environment.shim }}"
+
+          if [ "$SHIM" = "remote" ]; then
+            VALUES_FILE="values/kata-remote.yaml"
+          else
+            case "$ARCH" in
+              x86_64)
+                VALUES_FILE="values.yaml"
+                ;;
+              s390x)
+                VALUES_FILE="values/kata-s390x.yaml"
+                ;;
+              *)
+                echo "❌ Unsupported architecture: $ARCH"
+                exit 1
+                ;;
+            esac
+          fi
           
           # Use shim from matrix
           RUNTIME_CLASS_SHIM="${{ matrix.environment.shim }}"
@@ -471,6 +515,59 @@ jobs:
           daemonset-timeout: 15m
           daemonset-label: ${{ steps.deployment-params.outputs.daemonset-label }}
 
+      - name: Verify peerpods deployment
+        if: steps.should-run.outputs.should-run == 'true' && matrix.environment.shim == 'remote'
+        run: |
+          echo "🔍 Verifying peerpods components..."
+
+          # kata-deploy reconfigures containerd after installing shims.
+          # On k3s, containerd is embedded so this restarts the entire
+          # k3s process, taking the API server offline temporarily.
+          # Wait for the API server to come back before checking pods.
+          echo "⏳ Waiting for API server to be ready..."
+          TIMEOUT=120
+          ELAPSED=0
+          while [ $ELAPSED -lt $TIMEOUT ]; do
+            if kubectl get --raw /readyz &>/dev/null; then
+              echo "✅ API server ready after ${ELAPSED}s"
+              break
+            fi
+            sleep 5
+            ELAPSED=$((ELAPSED + 5))
+          done
+          if [ $ELAPSED -ge $TIMEOUT ]; then
+            echo "❌ API server not ready after ${TIMEOUT}s"
+            exit 1
+          fi
+
+          echo "⏳ Waiting for cloud-api-adaptor DaemonSet..."
+          kubectl wait --timeout=180s -n coco-system pod -l app=cloud-api-adaptor --for=condition=ready || {
+            echo "❌ CAA DaemonSet not ready"
+            kubectl get pods -n coco-system -l app=cloud-api-adaptor
+            kubectl describe pods -n coco-system -l app=cloud-api-adaptor
+            exit 1
+          }
+          echo "✅ cloud-api-adaptor DaemonSet is ready"
+
+          echo "⏳ Waiting for peerpodctrl-controller-manager..."
+          kubectl wait --timeout=180s -n coco-system deployment/peerpodctrl-controller-manager --for=condition=available || {
+            echo "❌ peerpod-ctrl not available"
+            kubectl get deployment -n coco-system
+            exit 1
+          }
+          echo "✅ peerpodctrl-controller-manager is available"
+
+          echo "🔍 Checking MutatingWebhookConfiguration..."
+          if kubectl get mutatingwebhookconfigurations | grep -q peer-pods; then
+            echo "✅ peerpods webhook is registered"
+          else
+            echo "❌ peerpods webhook not found"
+            kubectl get mutatingwebhookconfigurations
+            exit 1
+          fi
+
+          echo "✅ All peerpods components verified"
+
       - name: Get new containerd version
         if: steps.should-run.outputs.should-run == 'true' && matrix.environment.test-containerd-upgrade
         id: new-containerd-version
@@ -519,7 +616,7 @@ jobs:
           echo "   To:   ${{ steps.new-containerd-version.outputs.version }}"
 
       - name: Run test pod
-        if: steps.should-run.outputs.should-run == 'true'
+        if: steps.should-run.outputs.should-run == 'true' && matrix.environment.shim != 'remote'
         uses: ./.github/actions/run-test-pod
         with:
           runtime-class: ${{ steps.deployment-params.outputs.first-runtime-class }}

--- a/.github/workflows/helm-validation.yaml
+++ b/.github/workflows/helm-validation.yaml
@@ -97,6 +97,8 @@ jobs:
           echo "🔍 Testing remote (peer-pods) architecture..."
           helm template test-release . \
             -f values/kata-remote.yaml \
+            --set peerpods.provider=docker \
+            --set-json 'peerpods.providerConfigs={"docker":{}}' \
             > /tmp/remote-output.yaml
           echo "✅ remote template renders successfully"
 

--- a/Chart.lock
+++ b/Chart.lock
@@ -2,5 +2,8 @@ dependencies:
 - name: kata-deploy
   repository: oci://ghcr.io/kata-containers/kata-deploy-charts
   version: 3.26.0
-digest: sha256:97b15fd13a64082ec3f1311e59e142616be78b805e34c8a21ea256b66f0048d8
-generated: "2026-01-29T09:13:12.223808063+01:00"
+- name: peerpods
+  repository: file://../cloud-api-adaptor/src/cloud-api-adaptor/install/charts/peerpods
+  version: 0.1.0-dev
+digest: sha256:b25ee58abf8d227968c24584762b865ac6ed137364a6e604e9468b10ec0c3d82
+generated: "2026-02-10T11:38:41.799950091-05:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -18,3 +18,7 @@ dependencies:
     version: "3.26.0"
     repository: "oci://ghcr.io/kata-containers/kata-deploy-charts"
     condition: kata-as-coco-runtime.enabled
+  - name: peerpods
+    version: "0.1.1"
+    repository: "oci://ghcr.io/confidential-containers/cloud-api-adaptor/charts"
+    condition: peerpods.enabled

--- a/PEERPODS.md
+++ b/PEERPODS.md
@@ -1,0 +1,69 @@
+# Peer Pods (Cloud API Adaptor)
+
+Peer Pods enables running Kata Containers workloads in cloud VMs instead of
+local VMMs. This chart includes the
+[Cloud API Adaptor (CAA)](https://github.com/confidential-containers/cloud-api-adaptor)
+as an optional subchart, deployed when `values/kata-remote.yaml` is used.
+
+For detailed documentation on CAA, provider configuration, and architecture,
+see the [peerpods chart README](https://github.com/confidential-containers/cloud-api-adaptor/tree/main/src/cloud-api-adaptor/install/charts/peerpods).
+
+> [!WARNING]
+> When peerpods is enabled via `values/kata-remote.yaml`, all non-remote shims
+> are disabled. This means peerpods replaces other kata runtime configurations
+> rather than running alongside them. A mixed deployment (peerpods + local VMM
+> shims) is not currently supported.
+
+## Prerequisites
+
+- [cert-manager](https://cert-manager.io/docs/installation/) installed in the
+  cluster (required by the peerpods webhook)
+- Worker nodes labeled with `node.kubernetes.io/worker=`
+
+## General Installation
+
+The installation uses `values/kata-remote.yaml` to enable the peerpods
+subchart and configure the kata `remote` shim:
+
+```bash
+# Label worker nodes
+kubectl label node <node-name> node.kubernetes.io/worker=
+
+# Install with peer-pods enabled
+helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
+  -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-remote.yaml \
+  --set peerpods.provider=<provider> \
+  -f <provider>.yaml \
+  --namespace coco-system \
+  --create-namespace
+```
+
+Each cloud provider requires its own configuration values and secrets. Refer to
+the [peerpods chart documentation](https://github.com/confidential-containers/cloud-api-adaptor/tree/main/src/cloud-api-adaptor/install/charts/peerpods)
+for provider-specific setup instructions, secrets management, and available
+configuration options.
+
+## How It Works
+
+When `values/kata-remote.yaml` is used, the chart deploys the kata `remote`
+shim via the parent chart's `kata-as-coco-runtime` and enables the peerpods
+subchart (CAA, peerpod controller, and webhook). The peerpods subchart's own
+`kata-deploy` dependency is disabled to avoid duplication.
+
+## Testing
+
+Detailed e2e tests for peerpods are maintained in the
+[CAA repository](https://github.com/confidential-containers/cloud-api-adaptor).
+The following providers are currently tested in CI:
+
+- AWS
+- Azure
+- IBMCloud
+- libvirt
+- docker
+
+## Uninstallation
+
+```bash
+helm uninstall coco --namespace coco-system
+```

--- a/README.md
+++ b/README.md
@@ -96,9 +96,6 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
   --create-namespace
 ```
 
-> [!NOTE]
-> Support for peer-pods requires installation using the [Cloud API Adaptor peer-pods helm charts](https://github.com/confidential-containers/cloud-api-adaptor/tree/main/src/cloud-api-adaptor/install/charts/peerpods) project.
-
 ### Detailed Installation Instructions
 
 For complete installation instructions, customization options, and troubleshooting, see [QUICKSTART.md](QUICKSTART.md),
@@ -130,6 +127,13 @@ which includes:
 
 The chart deploys architecture-appropriate TEE runtime shims. The kata-deploy daemonset will install the runtimes
 based on the specified architecture and underlying hardware capabilities.
+
+## Peer Pods
+
+This chart supports deploying [Peer Pods (Cloud API Adaptor)](https://github.com/confidential-containers/cloud-api-adaptor)
+as an optional subchart for running confidential workloads in cloud VMs.
+See [PEERPODS.md](PEERPODS.md) for prerequisites, installation, and
+provider configuration.
 
 ## Usage
 
@@ -177,9 +181,6 @@ The available RuntimeClasses depend on the architecture:
 | RuntimeClass  | Description |
 |---------------|-------------|
 | `kata-remote` | Peer-pods   |
-
-> [!NOTE]
-> Support for peer-pods requires installation using the [Cloud API Adaptor peer-pods helm charts](https://github.com/confidential-containers/cloud-api-adaptor/tree/main/src/cloud-api-adaptor/install/charts/peerpods) project.
 
 ### Verification
 
@@ -438,7 +439,7 @@ See the [Confidential Containers contributing guide](https://github.com/confiden
 - ✅ **Phase 1** - Comprehensive E2E test coverage, unified actions
 - ✅ **Phase 2** - Feature parity verification, edge case testing
 - ✅ **Phase 3** - Operator deprecation, migration guide
-- 🔄 **Phase 4** - Peer-pods support, additional platform testing
+- ✅ **Phase 4** - Peer-pods support, additional platform testing
 - 📋 **Phase 5** - Production hardening, documentation improvements
 
 ## License

--- a/values.yaml
+++ b/values.yaml
@@ -232,3 +232,8 @@ kata-as-coco-runtime:
   # Default shim per architecture
   defaultShim:
     amd64: qemu-snp
+
+# Peer Pods (Cloud API Adaptor) subchart
+# Disabled by default. Use values/kata-remote.yaml to enable.
+peerpods:
+  enabled: false

--- a/values/kata-remote.yaml
+++ b/values/kata-remote.yaml
@@ -1,7 +1,11 @@
 # Kata runtime configuration for peer-pods (architecture independent)
 # Usage: helm install coco oci://ghcr.io/.../confidential-containers -f https://raw.githubusercontent.com/confidential-containers/charts/main/values/kata-remote.yaml
 #
-# This file only overrides the remote shim configuration for peer-pods.
+# This file overrides the kata runtime configuration for peer-pods:
+# - Enables the remote shim (required for peer-pods)
+# - Disables all other shims
+# - Enables the peerpods subchart (Cloud API Adaptor)
+#
 # For the full list of configurable options and their descriptions,
 # see: values.yaml in the chart root
 #
@@ -9,7 +13,15 @@ kata-as-coco-runtime:
   imagePullPolicy: Always
   k8sDistribution: k8s
 
+  defaultShim:
+    amd64: remote
+    arm64: remote
+    s390x: remote
+    ppc64le: remote
+
   shims:
+    remote:
+      enabled: true
     qemu-snp:
       enabled: false
 
@@ -66,3 +78,11 @@ kata-as-coco-runtime:
 
     stratovirt:
       enabled: false
+
+# Peer Pods (Cloud API Adaptor) subchart
+# Disable kata-deploy within peerpods since the parent chart's
+# kata-as-coco-runtime already handles kata installation.
+peerpods:
+  enabled: true
+  kata-deploy:
+    enabled: false


### PR DESCRIPTION
Add peerpods chart as a dependency when peerpods is enabled and include a basic Docker workflow. Comprehensive e2e coverage for major providers (Azure, libvirt, AWS, IBM Cloud, Docker) already exists at the CAA CI level.

Fixes: #2