### PR TITLE
runtimes: Bump kata to 3.28.0

### DIFF
--- a/Chart.lock
+++ b/Chart.lock
@@ -1,7 +1,7 @@
 dependencies:
 - name: kata-deploy
   repository: oci://ghcr.io/kata-containers/kata-deploy-charts
-  version: 3.27.0
+  version: 3.28.0
 - name: peerpods
   repository: oci://ghcr.io/confidential-containers/cloud-api-adaptor/charts
   version: 0.1.1

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 dependencies:
   - name: kata-deploy
     alias: kata-as-coco-runtime
-    version: "3.27.0"
+    version: "3.28.0"
     repository: "oci://ghcr.io/kata-containers/kata-deploy-charts"
     condition: kata-as-coco-runtime.enabled
   - name: peerpods


### PR DESCRIPTION
Bump to 3.28.0 after latest kata release