### PR TITLE
peerpods: Bump peerpods chart to 0.1.2

### DIFF
--- a/Chart.yaml
+++ b/Chart.yaml
@@ -19,6 +19,6 @@ dependencies:
     repository: "oci://ghcr.io/kata-containers/kata-deploy-charts"
     condition: kata-as-coco-runtime.enabled
   - name: peerpods
-    version: "0.1.1"
+    version: "0.1.2"
     repository: "oci://ghcr.io/confidential-containers/cloud-api-adaptor/charts"
     condition: peerpods.enabled


### PR DESCRIPTION
Picks up kube-rbac-proxy registry move from gcr.io to registry.k8s.io. The gcr.io image became unavailable around March 7, causing webhook ImagePullBackOff and blocking all remote shim CI jobs.

Fixes: #62, #63, #64, #65, #66, #67, #68, #69, #70
Fixes: #71, #72, #73, #74, #76, #77