### PR TITLE
kata: Bump to 3.29.0 release

### DIFF
--- a/.github/scripts/k8s-setup.sh
+++ b/.github/scripts/k8s-setup.sh
@@ -122,16 +122,48 @@ install_kubeadm_components() {
     fi
     echo "✅ Using Kubernetes version: $k8s_ver"
 
-    curl -fsSL "https://pkgs.k8s.io/core:/stable:/${k8s_ver}/deb/Release.key" | sudo gpg --batch --yes --no-tty --dearmor -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
-    echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${k8s_ver}/deb/ /" | sudo tee /etc/apt/sources.list.d/kubernetes.list
+    local major minor prev_version
+    major="${k8s_ver%%.*}"
+    minor="${k8s_ver##*.}"
+    if [[ "${minor}" -eq 0 ]]; then
+        echo "❌ Cannot fallback from ${k8s_ver} (minor version is 0)"
+        exit 1
+    fi
+    prev_version="${major}.$((minor - 1))"
 
-    cat <<EOF | sudo tee /etc/apt/preferences.d/kubernetes
-Package: kubelet kubeadm kubectl cri-tools kubernetes-cni
-Pin: origin pkgs.k8s.io
-Pin-Priority: 1000
-EOF
+    local version=""
+    local candidate
+    for candidate in "${k8s_ver}" "${prev_version}"; do
+        echo "🔍 Trying Kubernetes ${candidate}"
 
-    sudo apt-get update && sudo apt-get -y install kubeadm kubelet kubectl --allow-downgrades
+        curl -fsSL "https://pkgs.k8s.io/core:/stable:/${candidate}/deb/Release.key" \
+            | sudo gpg --batch --yes --no-tty --dearmor \
+            -o /etc/apt/keyrings/kubernetes-apt-keyring.gpg
+        echo "deb [signed-by=/etc/apt/keyrings/kubernetes-apt-keyring.gpg] https://pkgs.k8s.io/core:/stable:/${candidate}/deb/ /" \
+            | sudo tee /etc/apt/sources.list.d/kubernetes.list
+
+        cat <<-EOF | sudo tee /etc/apt/preferences.d/kubernetes
+	Package: kubelet kubeadm kubectl cri-tools kubernetes-cni
+	Pin: origin pkgs.k8s.io
+	Pin-Priority: 1000
+	EOF
+
+        sudo apt-get update
+        if sudo apt-get -y install --dry-run kubeadm kubelet kubectl \
+            --allow-downgrades >/dev/null 2>&1; then
+            version="${candidate}"
+            break
+        fi
+        echo "⚠️  Kubernetes ${candidate} packages have unmet dependencies, trying previous minor version"
+    done
+
+    if [[ -z "${version}" ]]; then
+        echo "❌ Failed to find a Kubernetes version with installable packages (tried ${k8s_ver} and ${prev_version})"
+        exit 1
+    fi
+
+    echo "📦 Installing Kubernetes ${version}"
+    sudo apt-get -y install kubeadm kubelet kubectl --allow-downgrades
     sudo apt-mark hold kubeadm kubelet kubectl
     echo "✅ Kubernetes installed: $(kubeadm version -o short)"
 }

--- a/Chart.lock
+++ b/Chart.lock
@@ -1,9 +1,9 @@
 dependencies:
 - name: kata-deploy
   repository: oci://ghcr.io/kata-containers/kata-deploy-charts
-  version: 3.28.0
+  version: 3.29.0
 - name: peerpods
   repository: oci://ghcr.io/confidential-containers/cloud-api-adaptor/charts
   version: 0.1.3
-digest: sha256:76f3558afa2c07bbe4a88275fcf6b4e796e9edce2750f79a5cf149fcaa04b50a
-generated: "2026-03-26T09:17:04.812451867-04:00"
+digest: sha256:103ed4be4003183504e3d51e53504fcd5e79d04c30e901caa67f0216ce917e68
+generated: "2026-04-24T17:05:40.180677006+02:00"

--- a/Chart.yaml
+++ b/Chart.yaml
@@ -15,7 +15,7 @@ maintainers:
 dependencies:
   - name: kata-deploy
     alias: kata-as-coco-runtime
-    version: "3.28.0"
+    version: "3.29.0"
     repository: "oci://ghcr.io/kata-containers/kata-deploy-charts"
     condition: kata-as-coco-runtime.enabled
   - name: peerpods


### PR DESCRIPTION
In order to pick up part of the GHSA-q49m-57vm-c8cc

https://github.com/kata-containers/kata-containers/security/advisories/GHSA-q49m-57vm-c8cc