### PR TITLE
tests: Make kata-deploy verification deployment-mode aware

### DIFF
--- a/.github/actions/verify-deployment/action.yaml
+++ b/.github/actions/verify-deployment/action.yaml
@@ -18,6 +18,10 @@ inputs:
     description: 'Label selector for kata-deploy daemonset (e.g., name=kata-as-coco-runtime or name=kata-as-coco-runtime-for-ci)'
     required: false
     default: 'name=kata-as-coco-runtime'
+  deployment-mode:
+    description: 'kata-deploy deployment mode: daemonset or job. In job mode there is no always-on DaemonSet; verification waits for the per-node install Jobs to label the node(s).'
+    required: false
+    default: 'daemonset'
 
 outputs:
   verification-status:
@@ -27,28 +31,31 @@ outputs:
 runs:
   using: composite
   steps:
-    - name: Wait for kata-deploy daemonset
+    - name: Wait for kata-deploy install
       shell: bash
       run: |
         ${{ github.action_path }}/../../scripts/k8s-operations.sh deployment wait-daemonset \
           --namespace ${{ inputs.namespace }} \
           --label ${{ inputs.daemonset-label }} \
-          --timeout ${{ inputs.daemonset-timeout }}
+          --timeout ${{ inputs.daemonset-timeout }} \
+          --deployment-mode ${{ inputs.deployment-mode }}
 
-    - name: Verify daemonset status
+    - name: Verify kata-deploy install status
       shell: bash
       run: |
         ${{ github.action_path }}/../../scripts/k8s-operations.sh deployment verify-daemonset \
           --namespace ${{ inputs.namespace }} \
-          --label ${{ inputs.daemonset-label }}
+          --label ${{ inputs.daemonset-label }} \
+          --deployment-mode ${{ inputs.deployment-mode }}
 
-    - name: Show daemonset logs
+    - name: Show kata-deploy logs
       shell: bash
       run: |
         ${{ github.action_path }}/../../scripts/k8s-operations.sh deployment show-logs \
           --namespace ${{ inputs.namespace }} \
           --label ${{ inputs.daemonset-label }} \
-          --tail 50
+          --tail 50 \
+          --deployment-mode ${{ inputs.deployment-mode }}
 
     - name: Verify RuntimeClasses
       id: verify

--- a/.github/scripts/common.sh
+++ b/.github/scripts/common.sh
@@ -29,6 +29,21 @@ retry_kubectl() {
     done
 }
 
+# Convert a Kubernetes-style duration (e.g. "15m", "90s", "1h", or a plain
+# number meaning seconds) into an integer number of seconds. Used by the
+# job-mode polling loops that need a numeric deadline rather than a string the
+# way `kubectl wait --timeout` consumes it.
+# Usage: secs=$(duration_to_seconds "15m")
+duration_to_seconds() {
+    local duration="$1"
+    case "$duration" in
+        *h) echo $(( ${duration%h} * 3600 )) ;;
+        *m) echo $(( ${duration%m} * 60 )) ;;
+        *s) echo "${duration%s}" ;;
+        *)  echo "$duration" ;;
+    esac
+}
+
 # Retry wrapper for pod creation with transient failure handling
 # Retries pod creation and waiting up to 5 times on failure
 # This handles flaky network issues during image pulls inside the guest

--- a/.github/scripts/k8s-deployment-verification.sh
+++ b/.github/scripts/k8s-deployment-verification.sh
@@ -10,18 +10,77 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # shellcheck source=common.sh
 source "${SCRIPT_DIR}/common.sh"
 
+# Node label kata-deploy applies once an install completes (both daemonset and
+# job deployment modes). In "job" mode there is no always-on DaemonSet to wait
+# on, so this label is the "install complete" signal.
+KATA_RUNTIME_NODE_LABEL="katacontainers.io/kata-runtime=true"
+
+# In daemonset mode the deployment is selected via "name=<chart>". In job mode
+# the dispatcher Job, per-node install Jobs and the templates ConfigMap are
+# selected via "app.kubernetes.io/name=<chart>". Derive the latter from the
+# former so callers keep passing a single --label value.
+job_label_from_daemonset_label() {
+    local label="$1"
+    if [[ "$label" == name=* ]]; then
+        echo "app.kubernetes.io/name=${label#name=}"
+    else
+        echo "$label"
+    fi
+}
+
+# Dump everything useful about the job-mode install pipeline (dispatcher Job,
+# per-node Jobs and their pods/logs) for post-mortem debugging.
+dump_job_mode_diagnostics() {
+    local namespace="$1" job_label="$2"
+    retry_kubectl kubectl -n "$namespace" get jobs -l "$job_label" -o wide || true
+    retry_kubectl kubectl -n "$namespace" get pods -l "$job_label" -o wide || true
+    kubectl -n "$namespace" describe jobs -l "$job_label" || true
+    kubectl -n "$namespace" logs -l "$job_label" --all-containers --tail=-1 --timestamps 2>/dev/null || true
+}
+
+# Wait until at least one node carries the kata-runtime label, which kata-deploy
+# only applies after the per-node install Job finishes (artifacts extracted, CRI
+# reconfigured, node labeled).
+wait_job_install() {
+    local namespace="$1" job_label="$2" timeout="$3"
+    local timeout_secs deadline
+    timeout_secs="$(duration_to_seconds "$timeout")"
+    deadline=$(( $(date +%s) + timeout_secs ))
+
+    echo "⏳ deploymentMode=job: waiting for per-node install Jobs to label node(s) (timeout: $timeout)..."
+    while true; do
+        if [ -n "$(kubectl get nodes -l "$KATA_RUNTIME_NODE_LABEL" -o name 2>/dev/null)" ]; then
+            echo "✅ At least one node carries the kata-runtime label (install complete)"
+            return 0
+        fi
+        if [ "$(date +%s)" -ge "$deadline" ]; then
+            echo "❌ Timed out waiting for kata-deploy install Jobs to label any node"
+            dump_job_mode_diagnostics "$namespace" "$job_label"
+            exit 1
+        fi
+        sleep 5
+    done
+}
+
 wait_daemonset() {
     local namespace="coco-system" label="name=kata-as-coco-runtime" timeout="15m"
+    local deployment_mode="daemonset"
     
     while [ $# -gt 0 ]; do
         case "$1" in
             --namespace) namespace="$2"; shift 2 ;;
             --label) label="$2"; shift 2 ;;
             --timeout) timeout="$2"; shift 2 ;;
+            --deployment-mode) deployment_mode="$2"; shift 2 ;;
             *) echo "Unknown option: $1"; exit 1 ;;
         esac
     done
-    
+
+    if [ "$deployment_mode" = "job" ]; then
+        wait_job_install "$namespace" "$(job_label_from_daemonset_label "$label")" "$timeout"
+        return
+    fi
+
     echo "⏳ Waiting for daemonset (label: $label, timeout: $timeout)..."
     
     if retry_kubectl kubectl wait --for=condition=ready pod -l "$label" -n "$namespace" --timeout="$timeout"; then
@@ -35,16 +94,43 @@ wait_daemonset() {
     fi
 }
 
+verify_job_install() {
+    local namespace="$1" job_label="$2"
+
+    echo "🔍 deploymentMode=job: verifying install Jobs and node labels..."
+    retry_kubectl kubectl -n "$namespace" get jobs -l "$job_label" -o wide || true
+
+    local labeled_nodes
+    labeled_nodes="$(kubectl get nodes -l "$KATA_RUNTIME_NODE_LABEL" -o name 2>/dev/null || echo "")"
+    if [ -n "$labeled_nodes" ]; then
+        echo "✅ Node(s) labeled with kata-runtime:"
+        echo "$labeled_nodes"
+        [ -n "${GITHUB_OUTPUT:-}" ] && echo "status=success" >> "$GITHUB_OUTPUT"
+    else
+        echo "❌ No nodes labeled with kata-runtime"
+        dump_job_mode_diagnostics "$namespace" "$job_label"
+        [ -n "${GITHUB_OUTPUT:-}" ] && echo "status=failed" >> "$GITHUB_OUTPUT"
+        exit 1
+    fi
+}
+
 verify_daemonset() {
     local namespace="coco-system" label="name=kata-as-coco-runtime"
+    local deployment_mode="daemonset"
     
     while [ $# -gt 0 ]; do
         case "$1" in
             --namespace) namespace="$2"; shift 2 ;;
             --label) label="$2"; shift 2 ;;
+            --deployment-mode) deployment_mode="$2"; shift 2 ;;
             *) echo "Unknown option: $1"; exit 1 ;;
         esac
     done
+
+    if [ "$deployment_mode" = "job" ]; then
+        verify_job_install "$namespace" "$(job_label_from_daemonset_label "$label")"
+        return
+    fi
     
     echo "🔍 Verifying daemonset..."
     
@@ -80,15 +166,25 @@ verify_daemonset() {
 
 show_logs() {
     local namespace="coco-system" label="name=kata-as-coco-runtime" tail="50"
+    local deployment_mode="daemonset"
     
     while [ $# -gt 0 ]; do
         case "$1" in
             --namespace) namespace="$2"; shift 2 ;;
             --label) label="$2"; shift 2 ;;
             --tail) tail="$2"; shift 2 ;;
+            --deployment-mode) deployment_mode="$2"; shift 2 ;;
             *) echo "Unknown option: $1"; exit 1 ;;
         esac
     done
+
+    if [ "$deployment_mode" = "job" ]; then
+        local job_label
+        job_label="$(job_label_from_daemonset_label "$label")"
+        echo "📋 kata-deploy job logs (last $tail lines):"
+        retry_kubectl kubectl logs -n "$namespace" -l "$job_label" --tail="$tail" --prefix=true || true
+        return
+    fi
     
     echo "📋 DaemonSet logs (last $tail lines):"
     retry_kubectl kubectl logs -n "$namespace" -l "$label" --tail="$tail" --prefix=true

--- a/.github/scripts/k8s-operations.sh
+++ b/.github/scripts/k8s-operations.sh
@@ -65,24 +65,29 @@ Categories & Commands:
 
 === DEPLOYMENT CATEGORY ===
   deployment wait-daemonset [OPTIONS]
-      Wait for kata-deploy daemonset to become ready
+      Wait for the kata-deploy install to complete
       Options:
         --namespace NAME          Namespace (default: coco-system)
         --label SELECTOR          Label selector (default: name=kata-as-coco-runtime)
         --timeout TIME            Timeout (default: 15m)
+        --deployment-mode MODE    daemonset or job (default: daemonset). In job
+                                  mode there is no always-on DaemonSet, so this
+                                  waits for a node to gain the kata-runtime label.
 
   deployment verify-daemonset [OPTIONS]
-      Verify daemonset status
+      Verify the kata-deploy install status
       Options:
         --namespace NAME          Namespace (default: coco-system)
         --label SELECTOR          Label selector (default: name=kata-as-coco-runtime)
+        --deployment-mode MODE    daemonset or job (default: daemonset)
 
   deployment show-logs [OPTIONS]
-      Show daemonset logs
+      Show kata-deploy logs
       Options:
         --namespace NAME          Namespace (default: coco-system)
         --label SELECTOR          Label selector (default: name=kata-as-coco-runtime)
         --tail LINES              Number of lines (default: 50)
+        --deployment-mode MODE    daemonset or job (default: daemonset)
 
   deployment verify-runtimeclasses RUNTIMECLASS [RUNTIMECLASS...]
       Verify RuntimeClasses exist

--- a/.github/workflows/e2e-tests.yaml
+++ b/.github/workflows/e2e-tests.yaml
@@ -449,6 +449,28 @@ jobs:
           
           echo "values-file=${VALUES_FILE}" >> $GITHUB_OUTPUT
 
+          # Detect the kata-deploy deployment mode from the values file so the
+          # verification step knows whether to expect a DaemonSet or per-node
+          # install Jobs. We do NOT enforce "job" mode anywhere yet: this
+          # defaults to "daemonset" and only changes behaviour if a values file
+          # opts into deploymentMode: job.
+          DEPLOYMENT_MODE=$(yq eval '.kata-as-coco-runtime.deploymentMode // "daemonset"' "${VALUES_FILE}" 2>/dev/null || echo "daemonset")
+          if [ -z "${DEPLOYMENT_MODE}" ] || [ "${DEPLOYMENT_MODE}" = "null" ]; then
+            DEPLOYMENT_MODE="daemonset"
+          fi
+          echo "deployment-mode=${DEPLOYMENT_MODE}" >> $GITHUB_OUTPUT
+          echo "ℹ️  kata-deploy deployment mode: ${DEPLOYMENT_MODE}"
+
+          # In "job" mode the dispatcher's default node selector targets only
+          # worker (non-control-plane) nodes. CI clusters are typically
+          # single-node, where the only node carries the control-plane label, so
+          # clear the role filter to target every discovered node.
+          JOB_EXTRA_ARGS=""
+          if [ "${DEPLOYMENT_MODE}" = "job" ]; then
+            JOB_EXTRA_ARGS="--set-json kata-as-coco-runtime.job.nodeSelectorExpressions=[]"
+          fi
+          echo "job-extra-args=${JOB_EXTRA_ARGS}" >> $GITHUB_OUTPUT
+
           # Get all available shims from values.yaml using new structured format
           # Extract shim names where enabled=true from kata-as-coco-runtime.shims
           # yq outputs each shim on a separate line, so we collect them into a space-separated string
@@ -503,7 +525,7 @@ jobs:
           release-name: ${{ steps.deployment-params.outputs.release-name }}
           namespace: coco-system
           values-file: ${{ steps.deployment-params.outputs.values-file }}
-          extra-args: ${{ steps.helm-args.outputs.args }}
+          extra-args: ${{ steps.helm-args.outputs.args }} ${{ steps.deployment-params.outputs.job-extra-args }}
           wait-timeout: 15m
 
       - name: Verify deployment
@@ -514,6 +536,7 @@ jobs:
           expected-runtime-classes: ${{ steps.deployment-params.outputs.expected-runtimeclasses }}
           daemonset-timeout: 15m
           daemonset-label: ${{ steps.deployment-params.outputs.daemonset-label }}
+          deployment-mode: ${{ steps.deployment-params.outputs.deployment-mode }}
 
       - name: Verify peerpods deployment
         if: steps.should-run.outputs.should-run == 'true' && matrix.environment.shim == 'remote'


### PR DESCRIPTION
Prepare CI for kata-deploy's "job" deployment mode without enforcing it. The bundled subchart is still DaemonSet-only, so everything defaults to "daemonset" and current runs are unchanged; only a values file opting into deploymentMode: job changes behaviour.


Assisted-by: Cursor <cursoragent@cursor.com>