### PR TITLE
values yaml: enable runtime-rs shims

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -30,11 +30,11 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
 
 **What you get:**
 
-- AMD SEV-SNP support (`kata-qemu-snp`)
-- Intel TDX support (`kata-qemu-tdx`)
-- NVIDIA GPU with SEV-SNP (`kata-qemu-nvidia-gpu-snp`)
-- NVIDIA GPU with TDX (`kata-qemu-nvidia-gpu-tdx`)
-- Development runtime (`kata-qemu-coco-dev`)
+- AMD SEV-SNP support (`kata-qemu-snp-runtime-rs`)
+- Intel TDX support (`kata-qemu-tdx-runtime-rs`)
+- NVIDIA GPU with SEV-SNP (`kata-qemu-nvidia-gpu-snp-runtime-rs`)
+- NVIDIA GPU with TDX (`kata-qemu-nvidia-gpu-tdx-runtime-rs`)
+- Development runtime (`kata-qemu-coco-dev-runtime-rs`)
 
 #### For s390x (IBM Z)
 
@@ -103,7 +103,7 @@ kind: Pod
 metadata:
   name: confidential-pod-snp
 spec:
-  runtimeClassName: kata-qemu-snp
+  runtimeClassName: kata-qemu-snp-runtime-rs
   containers:
     - name: app
       image: nginx:latest
@@ -117,7 +117,7 @@ kind: Pod
 metadata:
   name: confidential-pod-tdx
 spec:
-  runtimeClassName: kata-qemu-tdx
+  runtimeClassName: kata-qemu-tdx-runtime-rs
   containers:
     - name: app
       image: nginx:latest
@@ -282,8 +282,8 @@ helm install coco oci://ghcr.io/confidential-containers/charts/confidential-cont
 
 ```bash
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
-  --set kata-as-coco-runtime.env.shims="qemu-snp qemu-tdx qemu-coco-dev" \
-  --set kata-as-coco-runtime.env.snapshotterHandlerMapping="qemu-snp:nydus\,qemu-tdx:nydus\,qemu-coco-dev:nydus" \
+  --set kata-as-coco-runtime.env.shims="qemu-snp-runtime-rs qemu-tdx-runtime-rs qemu-coco-dev-runtime-rs" \
+  --set kata-as-coco-runtime.env.snapshotterHandlerMapping="qemu-snp-runtime-rs:nydus\,qemu-tdx-runtime-rs:nydus\,qemu-coco-dev-runtime-rs:nydus" \
   --namespace coco-system \
   --create-namespace
 ```
@@ -335,7 +335,7 @@ appropriate shim):
 # Force TDX as the default shim on x86_64
 
 helm install coco oci://ghcr.io/confidential-containers/charts/confidential-containers \
-  --set kata-as-coco-runtime.env.defaultShim=qemu-tdx \
+  --set kata-as-coco-runtime.env.defaultShim=qemu-tdx-runtime-rs \
   --namespace coco-system \
   --create-namespace
 ```
@@ -515,8 +515,8 @@ The Helm chart provides equivalent functionality with simpler configuration.
 ### x86_64 with NVIDIA GPU
 
 - Requires NVIDIA GPU
-- Use `kata-qemu-nvidia-gpu-snp` for AMD SEV-SNP + GPU
-- Use `kata-qemu-nvidia-gpu-tdx` for Intel TDX + GPU
+- Use `kata-qemu-nvidia-gpu-snp-runtime-rs` for AMD SEV-SNP + GPU
+- Use `kata-qemu-nvidia-gpu-tdx-runtime-rs` for Intel TDX + GPU
 
 ### s390x
 

--- a/README.md
+++ b/README.md
@@ -146,7 +146,7 @@ kind: Pod
 metadata:
   name: confidential-pod
 spec:
-  runtimeClassName: kata-qemu-coco-dev  # Choose from available RuntimeClasses
+  runtimeClassName: kata-qemu-coco-dev-runtime-rs  # Choose from available RuntimeClasses
   containers:
     - name: app
       image: your-image:tag
@@ -158,21 +158,21 @@ The available RuntimeClasses depend on the architecture:
 
 #### x86_64
 
-| RuntimeClass                    | Description                              |
-|---------------------------------|------------------------------------------|
-| `kata-qemu-coco-dev`            | Development/testing runtime              |
-| `kata-qemu-coco-dev-runtime-rs` | Development/testing runtime (Rust-based) |
-| `kata-qemu-snp`                 | AMD SEV-SNP                              |
-| `kata-qemu-tdx`                 | Intel TDX                                |
-| `kata-qemu-nvidia-gpu-snp`      | NVIDIA GPU with AMD SEV-SNP protection   |
-| `kata-qemu-nvidia-gpu-tdx`      | NVIDIA GPU with Intel TDX protection     |
+| RuntimeClass                          | Description                              |
+|---------------------------------------|------------------------------------------|
+| `kata-qemu-snp-runtime-rs`            | AMD SEV-SNP                              |
+| `kata-qemu-tdx-runtime-rs`            | Intel TDX                                |
+| `kata-qemu-coco-dev`                  | Development/testing runtime              |
+| `kata-qemu-coco-dev-runtime-rs`       | Development/testing runtime (Rust-based) |
+| `kata-qemu-nvidia-gpu-snp-runtime-rs` | NVIDIA GPU with AMD SEV-SNP protection   |
+| `kata-qemu-nvidia-gpu-tdx-runtime-rs` | NVIDIA GPU with Intel TDX protection     |
 
 #### s390x
 
 | RuntimeClass                    | Description                              |
 |---------------------------------|------------------------------------------|
 | `kata-qemu-coco-dev`            | Development/testing runtime              |
-| `kata-qemu-coco-dev-runtime-rs` | Development/testing runtime (Rust-based) |
+| `kata-qemu-coco-dev-runtime-rs` | Development/testing runtime(Rust-based)  |
 | `kata-qemu-se`                  | IBM Secure Execution                     |
 | `kata-qemu-se-runtime-rs`       | IBM Secure Execution (Rust-based)        |
 

--- a/examples-custom-values.yaml
+++ b/examples-custom-values.yaml
@@ -13,7 +13,7 @@ kata-as-coco-runtime:
     setup: ["nydus"]
 
   shims:
-    qemu-coco-dev:
+    qemu-coco-dev-runtime-rs:
       enabled: true
       supportedArches:
         - amd64
@@ -45,12 +45,12 @@ architecture: x86_64
 
 kata-as-coco-runtime:
   debug: false
-  
+
   snapshotter:
     setup: ["nydus"]
 
   shims:
-    qemu-snp:
+    qemu-snp-runtime-rs:
       enabled: true
       supportedArches:
         - amd64
@@ -63,7 +63,7 @@ kata-as-coco-runtime:
         httpsProxy: "http://proxy.example.com:8080"
         noProxy: "localhost,127.0.0.1"
 
-    qemu-tdx:
+    qemu-tdx-runtime-rs:
       enabled: true
       supportedArches:
         - amd64
@@ -76,7 +76,7 @@ kata-as-coco-runtime:
         httpsProxy: "http://proxy.example.com:8080"
         noProxy: "localhost,127.0.0.1"
 
-    qemu-coco-dev:
+    qemu-coco-dev-runtime-rs:
       enabled: true
       supportedArches:
         - amd64
@@ -93,19 +93,20 @@ kata-as-coco-runtime:
 ---
 # Example 3: x86_64 with custom image and selected shims
 # Note: qemu-nvidia-gpu-snp and qemu-nvidia-gpu-tdx are not in our standard set
-# This example shows the shims we expose: qemu-snp, qemu-tdx, qemu-coco-dev
+# This example shows the runtime-rs shims we expose:
+# qemu-snp-runtime-rs, qemu-tdx-runtime-rs, qemu-coco-dev-runtime-rs
 architecture: x86_64
 
 kata-as-coco-runtime:
   image:
     reference: quay.io/kata-containers/kata-deploy
   debug: true
-  
+
   snapshotter:
     setup: ["nydus"]
-  
+
   shims:
-    qemu-snp:
+    qemu-snp-runtime-rs:
       enabled: true
       supportedArches:
         - amd64
@@ -114,8 +115,8 @@ kata-as-coco-runtime:
         forceGuestPull: false
       crio:
         guestPull: true
-  
-    qemu-tdx:
+
+    qemu-tdx-runtime-rs:
       enabled: true
       supportedArches:
         - amd64
@@ -124,8 +125,8 @@ kata-as-coco-runtime:
         forceGuestPull: false
       crio:
         guestPull: true
-  
-    qemu-coco-dev:
+
+    qemu-coco-dev-runtime-rs:
       enabled: true
       supportedArches:
         - amd64
@@ -153,7 +154,7 @@ kata-as-coco-runtime:
     setup: ["nydus"]
 
   shims:
-    qemu-snp:
+    qemu-snp-runtime-rs:
       enabled: true
       supportedArches:
         - amd64

--- a/templates/NOTES.txt
+++ b/templates/NOTES.txt
@@ -30,7 +30,7 @@ Use confidential containers in your pods by specifying a RuntimeClass:
   metadata:
     name: my-pod
   spec:
-    runtimeClassName: kata-qemu-snp  # Choose appropriate RuntimeClass for your hardware
+    runtimeClassName: kata-qemu-snp-runtime-rs  # Choose appropriate RuntimeClass for your hardware
     containers:
     - name: app
       image: your-image:tag

--- a/values.yaml
+++ b/values.yaml
@@ -55,7 +55,7 @@ customContainerd:
 #
 # Advanced customizations (kata-deploy specific options):
 #   image.tag: Override image tag (uses chart's appVersion by default)
-#   env.defaultShim: "" (default) | "qemu-snp" | "qemu-tdx" | etc.
+#   env.defaultShim: "" (default) | "qemu-snp-runtime-rs" | "qemu-tdx-runtime-rs" | etc.
 #                    The default shim to use if `kata` is specified as the pod runtimeClass
 #   env.createRuntimeClasses: "true" (default) | "false"
 #                             Create Kubernetes RuntimeClass resources
@@ -91,10 +91,11 @@ kata-as-coco-runtime:
     setup: ["nydus"]
 
   # TEE (Trusted Execution Environment) shims configuration
-  # Only enable the shims we want to expose, explicitly disable all others
+  # Only enable the shims we want to expose, explicitly disable all others.
+  # Since Kata 4.0, runtime-rs is the default runtime.
   shims:
-    # Enabled shims - TEE shims we want to expose
-    qemu-snp:
+    # Enabled shims - runtime-rs TEE shims (default since Kata 4.0)
+    qemu-snp-runtime-rs:
       enabled: true
       supportedArches:
         - amd64
@@ -108,7 +109,7 @@ kata-as-coco-runtime:
         httpsProxy: ""
         noProxy: ""
 
-    qemu-tdx:
+    qemu-tdx-runtime-rs:
       enabled: true
       supportedArches:
         - amd64
@@ -154,7 +155,7 @@ kata-as-coco-runtime:
 
     # NVIDIA GPU shims with TEE protection
     # These use experimental-force-guest-pull to match kata-containers configuration
-    qemu-nvidia-gpu-snp:
+    qemu-nvidia-gpu-snp-runtime-rs:
       enabled: true
       supportedArches:
         - amd64
@@ -167,7 +168,7 @@ kata-as-coco-runtime:
         httpsProxy: ""
         noProxy: ""
 
-    qemu-nvidia-gpu-tdx:
+    qemu-nvidia-gpu-tdx-runtime-rs:
       enabled: true
       supportedArches:
         - amd64
@@ -180,7 +181,7 @@ kata-as-coco-runtime:
         httpsProxy: ""
         noProxy: ""
 
-    # Kata runtimes that are not for TEE
+    # Disabled shims - Go runtime variants and non-TEE runtimes 
     clh:
       enabled: false
 
@@ -199,16 +200,22 @@ kata-as-coco-runtime:
     qemu-runtime-rs:
       enabled: false
 
-    qemu-snp-runtime-rs:
+    qemu-snp:
       enabled: false
 
-    qemu-tdx-runtime-rs:
+    qemu-tdx:
       enabled: false
 
     qemu-cca:
       enabled: false
 
     qemu-nvidia-gpu:
+      enabled: false
+
+    qemu-nvidia-gpu-snp:
+      enabled: false
+
+    qemu-nvidia-gpu-tdx:
       enabled: false
 
     qemu-se:
@@ -231,7 +238,7 @@ kata-as-coco-runtime:
 
   # Default shim per architecture
   defaultShim:
-    amd64: qemu-snp
+    amd64: qemu-snp-runtime-rs
 
 # Peer Pods (Cloud API Adaptor) subchart
 # Disabled by default. Use values/kata-remote.yaml to enable.

--- a/values/profile-ci.yaml
+++ b/values/profile-ci.yaml
@@ -43,7 +43,7 @@ kata-as-coco-runtime:
     qemu-runtime-rs:
       enabled: false
 
-  # Default shim per architecture
+  # Default shim per architecture (runtime-rs since Kata 4.0)
   defaultShim:
-    amd64: qemu-coco-dev
-    s390x: qemu-coco-dev
+    amd64: qemu-coco-dev-runtime-rs
+    s390x: qemu-coco-dev-runtime-rs


### PR DESCRIPTION
Since Kata 4.0 uses the Rust runtime as the default, this PR enables all `runtime-rs` shims and configures them as the default runtime in the Helm charts.