### PR TITLE
charts: Enforce the "daemonset" deploymentMode

### DIFF
--- a/values.yaml
+++ b/values.yaml
@@ -81,6 +81,8 @@ kata-as-coco-runtime:
   k8sDistribution: k8s
   debug: false
 
+  deploymentMode: daemonset
+
   # Deploy TEE-enabled runtime shims for x86_64
   # For other architectures, use the appropriate values file:
   #   - values/kata-s390x.yaml for IBM Z

--- a/values/kata-alibabacloud-tdx.yaml
+++ b/values/kata-alibabacloud-tdx.yaml
@@ -11,6 +11,8 @@ kata-as-coco-runtime:
   k8sDistribution: k8s
   debug: false
 
+  deploymentMode: daemonset
+
   # Snapshotter configuration
   snapshotter:
     setup: ["nydus"]

--- a/values/kata-remote.yaml
+++ b/values/kata-remote.yaml
@@ -13,6 +13,8 @@ kata-as-coco-runtime:
   imagePullPolicy: Always
   k8sDistribution: k8s
 
+  deploymentMode: daemonset
+
   defaultShim:
     amd64: remote
     arm64: remote

--- a/values/kata-s390x.yaml
+++ b/values/kata-s390x.yaml
@@ -12,6 +12,8 @@ kata-as-coco-runtime:
   k8sDistribution: k8s
   debug: false
 
+  deploymentMode: daemonset
+
   # Snapshotter configuration
   snapshotter:
     setup: ["nydus"]

--- a/values/profile-ci.yaml
+++ b/values/profile-ci.yaml
@@ -18,6 +18,9 @@ kata-as-coco-runtime:
     tag: "kata-containers-latest"
   # Enable debug logging for CI testing
   debug: true
+
+  deploymentMode: daemonset
+
   # Snapshotter configuration (using new structured format)
   # This will be merged with the snapshotter config from base values files
   snapshotter:


### PR DESCRIPTION
Kata Containers switched away from the "daemonset" deployment mode due to the fact it's a high-privileged daemonset running on the host "forever".

Such switch ended up breaking the CoCo charts, so now I'm returning it to the "known to be passing tests" state, although the recommendation from the Kata Containers side is for the Confidential Containers to switch to the "job" deploymentMode sooner than later, as the "daemonset" deploymentMode will be deprecated and removed from Kata Containers.